### PR TITLE
Correction to description of DEFINE statement

### DIFF
--- a/query-languages/dax/define-statement-dax.md
+++ b/query-languages/dax/define-statement-dax.md
@@ -18,7 +18,7 @@ A keyword that defines entities that can be applied to one or more EVALUATE stat
 ## Syntax  
   
 ```dax
-DEFINE {  <entity> [<name>] = <expression> }
+DEFINE {  <entity> <name> = <expression> }
 ```
   
 ### Arguments


### PR DESCRIPTION
In my understanding<name> is required (not optional) in a DEFINE statement