### PR TITLE
Clarifying exclusive identifier behavior

### DIFF
--- a/query-languages/m/m-spec-basic-concepts.md
+++ b/query-languages/m/m-spec-basic-concepts.md
@@ -154,7 +154,7 @@ _exclusive-identifier-reference:<br/>
 
 It is an error for an _exclusive-identifier-reference_ to refer to a variable that is not part of the environment of the expression that the identifier appears within. 
 
-Inside a _record-initializer-expression_ or _let-expression_, it is an error for an _exclusive-identifier-reference_ to refer to an identifier that is currently being initialized. Instead, an _inclusive-identifier-reference_ can be used to gain access to the environment that includes the identifier being initialized. If an _inclusive-identifier-reference_ is used in a context where there is no identifier being initialized, then it is equivalent to an _exclusive-identifier-reference_.
+It is an error for an _exclusive-identifier-reference_ to refer to an identifier that is currently being initialized if referenced identifier is defined inside a _record-initializer-expression_ or  _let-expression_. Instead, an _inclusive-identifier-reference_ can be used to gain access to the environment that includes the identifier being initialized. If an _inclusive-identifier-reference_ is used in any other situation, then it is equivalent to an _exclusive-identifier-reference_.
 
 _inclusive-identifier-reference:_<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`@`  _identifier_

--- a/query-languages/m/m-spec-basic-concepts.md
+++ b/query-languages/m/m-spec-basic-concepts.md
@@ -154,7 +154,7 @@ _exclusive-identifier-reference:<br/>
 
 It is an error for an _exclusive-identifier-reference_ to refer to a variable that is not part of the environment of the expression that the identifier appears within. 
 
-Inside a `let` expression or record, it is an error for an _exclusive-identifier-reference_ to refer to an identifier that is currently being initialized. Instead, an _inclusive-identifier-reference_ can be used to gain access to the environment that includes the identifier being initialized. If an _inclusive-identifier-reference_ is used in a context where there is no identifier being initialized, then it is equivalent to an _exclusive-identifier-reference_.
+Inside a _record-initializer-expression_ or _let-expression_, it is an error for an _exclusive-identifier-reference_ to refer to an identifier that is currently being initialized. Instead, an _inclusive-identifier-reference_ can be used to gain access to the environment that includes the identifier being initialized. If an _inclusive-identifier-reference_ is used in a context where there is no identifier being initialized, then it is equivalent to an _exclusive-identifier-reference_.
 
 _inclusive-identifier-reference:_<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`@`  _identifier_

--- a/query-languages/m/m-spec-basic-concepts.md
+++ b/query-languages/m/m-spec-basic-concepts.md
@@ -154,7 +154,7 @@ _exclusive-identifier-reference:<br/>
 
 It is an error for an _exclusive-identifier-reference_ to refer to a variable that is not part of the environment of the expression that the identifier appears within. 
 
-It is an error for an _exclusive-identifier-reference_ to refer to an identifier that is currently being initialized if referenced identifier is defined inside a _record-initializer-expression_ or  _let-expression_. Instead, an _inclusive-identifier-reference_ can be used to gain access to the environment that includes the identifier being initialized. If an _inclusive-identifier-reference_ is used in any other situation, then it is equivalent to an _exclusive-identifier-reference_.
+It is an error for an _exclusive-identifier-reference_ to refer to an identifier that is currently being initialized if the referenced identifier is defined inside a _record-initializer-expression_ or _let-expression_. Instead, an _inclusive-identifier-reference_ can be used to gain access to the environment that includes the identifier being initialized. If an _inclusive-identifier-reference_ is used in any other situation, then it is equivalent to an _exclusive-identifier-reference_.
 
 _inclusive-identifier-reference:_<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`@`  _identifier_

--- a/query-languages/m/m-spec-basic-concepts.md
+++ b/query-languages/m/m-spec-basic-concepts.md
@@ -152,9 +152,9 @@ The simplest form of identifier reference is an _exclusive-identifier-reference_
 _exclusive-identifier-reference:<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;identifier_
 
-It is an error for an _exclusive-identifier-reference_ to refer to a variable that is not part of the environment of the expression that the identifier appears within, or to refer to an identifier that is currently being initialized.
+It is an error for an _exclusive-identifier-reference_ to refer to a variable that is not part of the environment of the expression that the identifier appears within. 
 
-An _inclusive-identifier-reference_ can be used to gain access to the environment that includes the identifier being initialized. If it used in a context where there is no identifier being initialized, then it is equivalent to an _exclusive-identifier-reference_.
+Inside a `let` expression or record, it is an error for an _exclusive-identifier-reference_ to refer to an identifier that is currently being initialized. Instead, an _inclusive-identifier-reference_ can be used to gain access to the environment that includes the identifier being initialized. If an _inclusive-identifier-reference_ is used in a context where there is no identifier being initialized, then it is equivalent to an _exclusive-identifier-reference_.
 
 _inclusive-identifier-reference:_<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`@`  _identifier_


### PR DESCRIPTION
Related: https://github.com/MicrosoftDocs/powerquery-docs/issues/151

Clarifying to reflect the fact the special exclusive identifier reference rules don't apply to global identifiers and `Section1!`-style references.