### PR TITLE
Update except-function-dax.md

### DIFF
--- a/query-languages/dax/except-function-dax.md
+++ b/query-languages/dax/except-function-dax.md
@@ -13,7 +13,7 @@ recommendations: false
 ---
 # EXCEPT
 
-Returns the rows of one table which do not appear in another table.  
+Returns the rows of the first table in the expression which do not appear in the second table.  
   
 ## Syntax  
   


### PR DESCRIPTION
Making the definition more explicit - records in first table listed not on the second. Will help the intellisense too since it seems these are shared.

The original of "rows in one table not in the other" is unclear which is the one being compared against.