### PR TITLE
Update calendarauto-function-dax.md

### DIFF
--- a/query-languages/dax/calendarauto-function-dax.md
+++ b/query-languages/dax/calendarauto-function-dax.md
@@ -49,4 +49,4 @@ In this example, the MinDate and MaxDate in the data model are July 1, 2010 and 
   
 `CALENDARAUTO()` will return all dates between January 1, 2010 and December 31, 2011.  
   
-`CALENDARAUTO(3)` will return all dates between March 1, 2010 and March 31, 2012.  
+`CALENDARAUTO(3)` will return all dates between April 1, 2010 and March 31, 2012.  


### PR DESCRIPTION
Fixed incorrect example results on line 52. Using CALENDARAUTO(3) for the min and max dates given, the dates will be between **April 1, 2010** and March 31, 2012.  Not **March 1, 2010** through March 31, 2012.