### PR TITLE
M Grammer Change: type supports primary-expression

### DIFF
--- a/query-languages/m/m-spec-consolidated-grammar.md
+++ b/query-languages/m/m-spec-consolidated-grammar.md
@@ -500,6 +500,7 @@ _type-expression:<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`type`  _primary-type<br/>
 type:<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;parenthesized-expression<br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;primary-expression<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;primary-type<br/>
 primary-type:<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;primitive-type<br/>

--- a/query-languages/m/m-spec-consolidated-grammar.md
+++ b/query-languages/m/m-spec-consolidated-grammar.md
@@ -499,7 +499,6 @@ _type-expression:<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;primary-expression_<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`type`  _primary-type<br/>
 type:<br/>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;parenthesized-expression<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;primary-expression<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;primary-type<br/>
 primary-type:<br/>

--- a/query-languages/m/m-spec-types.md
+++ b/query-languages/m/m-spec-types.md
@@ -31,7 +31,7 @@ _type-expression:<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;primary-expression_<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`type` _primary-type<br/> 
 type:<br/>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;parenthesized-expression<br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;primary-expression<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;primary-type<br/>
 primary-type:<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;primitive-type<br/>


### PR DESCRIPTION
In [M's consolidated grammar](https://learn.microsoft.com/en-us/powerquery-m/m-spec-consolidated-grammar#type-expression), _type_ is used for record field types, list item types, and table column types, and as the base type in a nullable type.

The grammar currently defines it as:
````
type:
      parenthesized-expression
      primary-type
````
Based on the above, only statements in the form of `(some expression)` or _primary-type_ references are allowed.

However, Query Editor accepts a much broader range of syntax as valid. Based on testing (see below), the accepted syntax appears to be at least a broad as _primary-expression_.

This PR adjusts _type_'s definition to reflect this broader range of allowed syntax.

## Test
When viewed in Query Editor's advanced editor, no syntax errors are reported for following M code:
````
// demo - uses each style of primary-expression as a column type, a list item type, and a record type, as well as with keyword "nullable"
{
    // record field type
    type [Field = "abc"], // literal-expression
    type [Field = {a}], // list-expression
    type [Field = [b=c]], // record-expression
    type [Field = b], // identifier-expression
    type [Field = b!c], // section-access-expression
    type [Field = (1+2)], // parenthesized-expression
    type [Field = [b]], // field-access-expression
    type [Field = b{1}], // tem-access-expression
    type [Field = b()], // invoke-expression
    type [Field = ...], // not-implemented-expression

    // list item type
    type { "abc" }, // literal-expression
    type { {a} }, // list-expression
    type { [b=c] }, // record-expression
    type { b }, // identifier-expression
    type { b!c }, // section-access-expression
    type { (1+2) }, // parenthesized-expression
    type { [b] }, // field-access-expression
    type { b{1} }, // tem-access-expression
    type { b() }, // invoke-expression
    type { ... }, // not-implemented-expression

    // table column type
    type table [Field = "abc"], // literal-expression
    type table [Field = {a}], // list-expression
    type table [Field = [b=c]], // record-expression
    type table [Field = b], // identifier-expression
    type table [Field = b!c], // section-access-expression
    type table [Field = (1+2)], // parenthesized-expression
    type table [Field = [b]], // field-access-expression
    type table [Field = b{1}], // tem-access-expression
    type table [Field = b()], // invoke-expression
    type table [Field = ...], // not-implemented-expression    

    // nullable type
    type nullable "abc", // literal-expression
    type nullable {a}, // list-expression
    type nullable [b=c], // record-expression
    type nullable b, // identifier-expression
    type nullable b!c, // section-access-expression
    type nullable (1+2), // parenthesized-expression
    type nullable [b], // field-access-expression
    type nullable b{1}, // tem-access-expression
    type nullable b(), // invoke-expression
    type nullable ... // not-implemented-expression    
}  
````