### PR TITLE
Clarifying type equality comparisons

### DIFF
--- a/query-languages/m/m-spec-types.md
+++ b/query-languages/m/m-spec-types.md
@@ -353,7 +353,7 @@ Value.Type( Value.ReplaceType( {1}, type {number} )
 
 ## Type equivalence and compatibility
 
-Type equivalence is not defined in M. Any two type values that are compared for equality may or may not return `true`. However, the relation between those two types (whether `true` or `false`) will always be the same.
+Type equivalence is not fully defined in M. It is acceptable for an M implementation to return `false` when type values are compared for equality. If `true` is returned, at minimum, the following criteria must be met: the two values must be based on the same nullable primitive type and the response returned must be consistent if the same values are repeatedly compared (that is, multiple recurrences of the same comparison must all either evaluate to `true` or to `false`). 
 
 Compatibility between a given type and a nullable primitive type can be determined using the library function `Type.Is`, which accepts an arbitrary type value as its first and a nullable primitive type value as its second argument:
 

--- a/query-languages/m/m-spec-types.md
+++ b/query-languages/m/m-spec-types.md
@@ -353,7 +353,7 @@ Value.Type( Value.ReplaceType( {1}, type {number} )
 
 ## Type equivalence and compatibility
 
-Type equivalence is not fully defined in M. It is acceptable for an M implementation to return `false` when type values are compared for equality. If `true` is returned, at minimum, the following criteria must be met: the two values must be based on the same nullable primitive type and the response returned must be consistent if the same values are repeatedly compared (that is, multiple recurrences of the same comparison must all either evaluate to `true` or to `false`). 
+Type equivalence is not defined in M. An M implementation may optionally choose to use its own rules to perform equality comparisons between type values, in which case `true` or `false` should be returned, as the implementation deems appropriate. Otherwise, comparing two type values for equality should evaluate to `false`. In either case, the response returned must be consistent if the same two values are repeatedly compared. 
 
 Compatibility between a given type and a nullable primitive type can be determined using the library function `Type.Is`, which accepts an arbitrary type value as its first and a nullable primitive type value as its second argument:
 

--- a/query-languages/m/m-spec-types.md
+++ b/query-languages/m/m-spec-types.md
@@ -353,7 +353,7 @@ Value.Type( Value.ReplaceType( {1}, type {number} )
 
 ## Type equivalence and compatibility
 
-Type equivalence is not defined in M. An M implementation may optionally choose to use its own rules to perform equality comparisons between type values, in which case `true` or `false` should be returned, as the implementation deems appropriate. Otherwise, comparing two type values for equality should evaluate to `false`. In either case, the response returned must be consistent if the same two values are repeatedly compared. 
+Type equivalence is not defined in M. An M implementation may optionally choose to use its own rules to perform equality comparisons between type values. Comparing two type values for equality should evaluate to `true` if they are considered identical by the implementation, and `false` otherwise. In either case, the response returned must be consistent if the same two values are repeatedly compared. Note that within a given implementation, comparing some identical type values (such as `(type text) = (type text)`) may return `true`, while comparing others (such as `(type [a = text]) = (type [a = text])`) may not.
 
 Compatibility between a given type and a nullable primitive type can be determined using the library function `Type.Is`, which accepts an arbitrary type value as its first and a nullable primitive type value as its second argument:
 


### PR DESCRIPTION
The M language spec currently [says](https://learn.microsoft.com/en-us/powerquery-m/m-spec-types#type-equivalence-and-compatibility):
> Any two type values that are compared for equality may or may not return `true`.

Technically speaking, this allows comparisons like `(type text) = (type number)` to evaluate to `true`—which is confusing behavior. :-)

I don't believe M's implementation is actually this wild. This PR is an attempt to scope down how this is defined to bring clarity.