### PR TITLE
Table.FromList: include example with identity splitter

### DIFF
--- a/query-languages/m/table-fromlist.md
+++ b/query-languages/m/table-fromlist.md
@@ -61,3 +61,29 @@ Table.FromRecords({
     [CustomerID = 2, Name = "Jim"]
 })
 ```
+
+## Example 3
+
+Create a table with a single column, from a List that may include commas `,`, where commas should not be treated as a separator character.
+
+**Usage**
+
+```powerquery-m
+Table.FromList(
+    {
+        "abcd",
+        ".,!?"
+    },
+    (x) => {x},
+    {"SomeStrings"}
+)
+```
+
+**Output**
+
+```powerquery-m
+Table.FromRecords({
+    [SomeStrings = "abcd"],
+    [SomeStrings = ".,!?"]
+})
+```

--- a/query-languages/m/table-fromlist.md
+++ b/query-languages/m/table-fromlist.md
@@ -13,30 +13,51 @@ Table.FromList(<b>list</b> as list, optional <b>splitter</b> as nullable functio
   
 ## About
 
-Converts a list, `list` into a table by applying the optional splitting function, `splitter`, to each item in the list. By default, the list is assumed to be a list of text values that is split by commas. Optional `columns` may be the number of columns, a list of columns or a TableType. Optional `default` and `extraValues` may also be specified.
+Converts a list, `list` into a table by applying the optional [splitting function](splitter-functions.md), `splitter`, to each item in the list. By default, the list is assumed to be a list of text values that is split by commas. Optional `columns` may be the number of columns, a list of columns or a TableType. Optional `default` and `extraValues` may also be specified.
 
 ## Example 1
 
-Create a table from the list with the column named "Letters" using the default splitter.
+Create a table from a list containing letters and words separated by a comma. The table will have "Letter" and "Example Word" as column names.
 
 **Usage**
 
 ```powerquery-m
-Table.FromList({"a", "b", "c", "d"}, null, {"Letters"})
+Table.FromList({"a,apple", "b,ball", "c,cookie", "d,door"}, null, {"Letter", "Example Word"})
 ```
 
 **Output**
 
 ```powerquery-m
 Table.FromRecords({
-    [Letters = "a"],
-    [Letters = "b"],
-    [Letters = "c"],
-    [Letters = "d"]
+    [Letter = "a", "Example Word" = "apple"],
+    [Letter = "b", "Example Word" = "ball"],
+    [Letter = "c", "Example Word" = "cookie"],
+    [Letter = "d", "Example Word" = "door"]
 })
 ```
 
 ## Example 2
+
+Create a table with a single column from a List, using a custom splitter.
+
+**Usage**
+
+```powerquery-m
+Table.FromList({"a,apple", "b,ball", "c,cookie", "d,door"}, Splitter.SplitByNothing(), {"Letter and Example Word"})
+```
+
+**Output**
+
+```powerquery-m
+Table.FromRecords({
+    ["Letter and Example Word" = "a,apple"],
+    ["Letter and Example Word" = "b,ball"],
+    ["Letter and Example Word" = "c,cookie"],
+    ["Letter and Example Word" = "d,door"]
+})
+```
+
+## Example 3
 
 Create a table from the list using the [Record.FieldValues](record-fieldvalues.md) splitter with the resulting table having "CustomerID" and "Name" as column names.
 
@@ -59,31 +80,5 @@ Table.FromList(
 Table.FromRecords({
     [CustomerID = 1, Name = "Bob"],
     [CustomerID = 2, Name = "Jim"]
-})
-```
-
-## Example 3
-
-Create a table with a single column, from a List that may include commas `,`, where commas should not be treated as a separator character.
-
-**Usage**
-
-```powerquery-m
-Table.FromList(
-    {
-        "abcd",
-        ".,!?"
-    },
-    (x) => {x},
-    {"SomeStrings"}
-)
-```
-
-**Output**
-
-```powerquery-m
-Table.FromRecords({
-    [SomeStrings = "abcd"],
-    [SomeStrings = ".,!?"]
 })
 ```

--- a/query-languages/m/table-fromlist.md
+++ b/query-languages/m/table-fromlist.md
@@ -17,7 +17,7 @@ Converts a list, `list` into a table by applying the optional [splitting functio
 
 ## Example 1
 
-Create a table from a list containing letters and words separated by a comma. The table will have "Letter" and "Example Word" as column names.
+Create a table from a list using the default splitter.
 
 **Usage**
 

--- a/query-languages/m/table-fromlist.md
+++ b/query-languages/m/table-fromlist.md
@@ -38,7 +38,7 @@ Table.FromRecords({
 
 ## Example 2
 
-Create a table with a single column from a List, using a custom splitter.
+Create a table from a list using a custom splitter.
 
 **Usage**
 
@@ -59,7 +59,7 @@ Table.FromRecords({
 
 ## Example 3
 
-Create a table from the list using the [Record.FieldValues](record-fieldvalues.md) splitter with the resulting table having "CustomerID" and "Name" as column names.
+Create a table from a list using the [Record.FieldValues](record-fieldvalues.md) splitter.
 
 **Usage**
 


### PR DESCRIPTION
The example is trivial for someone with experience writing M functions.

However, for someone starting writing M, this example provides a "learning by doing" way of defining and using a simple function and solving a simple problem.

If there is a better way of converting a list to a table without splitting by any character, then the documentation could refer to it instead of providing this example. As a beginner myself, I would find it helpful.

Thanks for providing sources for the documentation and for considering pull requests.