### PR TITLE
Aligning table type details with consolidated grammar

### DIFF
--- a/query-languages/m/m-spec-types.md
+++ b/query-languages/m/m-spec-types.md
@@ -252,7 +252,7 @@ A _table-type value_ is used to define the structure of a table value.
 _table-type:_<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`table` _row-type<br/> 
 row-type:_<br/>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`[`   _field-specification-list_<sub>opt</sub>  `]`
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`[`   _field-specification-list<sub>opt</sub>_  `]`
 
 The result of evaluating a _table-type_ is a type value whose base type is `table`.
 

--- a/query-languages/m/m-spec-types.md
+++ b/query-languages/m/m-spec-types.md
@@ -252,7 +252,7 @@ A _table-type value_ is used to define the structure of a table value.
 _table-type:_<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`table` _row-type<br/> 
 row-type:_<br/>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`[`   _field-specification-list_  `]`
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`[`   _field-specification-list_<sub>opt</sub>  `]`
 
 The result of evaluating a _table-type_ is a type value whose base type is `table`.
 


### PR DESCRIPTION
A grammar fragment on the types page was out of sync with the [consolidated grammar](https://learn.microsoft.com/en-us/powerquery-m/m-spec-consolidated-grammar#type-expression). Copying the definition from the consolidated grammar to the types page.