### PR TITLE
Function Type Parameter Specification Assertion Change: Allow "Complex" Types

### DIFF
--- a/query-languages/m/m-spec-consolidated-grammar.md
+++ b/query-languages/m/m-spec-consolidated-grammar.md
@@ -2,7 +2,7 @@
 title: M Language Consolidated Grammar 
 description: Describes all of the grammar associated with the Power Query M formula language
 ms.topic: conceptual
-ms.date: 8/2/2022
+ms.date: 9/15/2023
 ms.custom: "nonautomated-date"
 ---
 
@@ -449,14 +449,14 @@ fixed-parameter-list:<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;parameter<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;parameter_  `,`  _fixed-parameter-list<br/>
 parameter:<br/>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;parameter-name  parameter-type<sub>opt</sub><br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;parameter-name  primitive-parameter-type<sub>opt</sub><br/>
 parameter-name:<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;identifier<br/>
-parameter-type:<br/>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;assertion<br/>
+primitive-parameter-type:<br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;primitive-assertion<br/>
 return-type:<br/>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;assertion<br/>
-assertion:_<br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;primitive-assertion<br/>
+primitive-assertion:_<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`as`  _nullable-primitive-type<br/>
 optional-parameter-list:<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;optional-parameter<br/>
@@ -550,6 +550,10 @@ optional-parameter-specification:_<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`optional` _parameter-specification<br/> 
 parameter-specification:<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;parameter-name  parameter-type<br/>
+parameter-type:<br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;assertion<br/>
+assertion:_<br/>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`as` _type<br/>
 table-type:_<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`table`  _row-type<br/>
 row-type:_<br/>


### PR DESCRIPTION
Hello,

In the grammar, a function type's parameter specifications are based off of the following rule:
```
parameter-specification:
      parameter-name parameter-type
```

Where:
```
parameter-type:
      assertion

assertion:
      as nullable-primitive-type
```

However, Power Query in Power BI Desktop allows more complex types to be used for these assertions. Example:
```
type function (input as any, options as [PrettyPrint = logical, MaxLineCount = Int64.Type]) as any
```

This PR proposes an adjustment to reflect the fact that a function type parameter assertion can be more "complex" than a nullable primitive types while maintaining the fact that only nullable primitive types can be used when defining functions.

If the below looks good, will copy the relevant changes to https://learn.microsoft.com/en-us/powerquery-m/m-spec-types#function-types.