### PR TITLE
Change **argname** to <b>argname</b>

### DIFF
--- a/query-languages/m/cube-addandexpanddimensioncolumn.md
+++ b/query-languages/m/cube-addandexpanddimensioncolumn.md
@@ -6,7 +6,8 @@ title: "Cube.AddAndExpandDimensionColumn"
 
 ## Syntax
 
-<pre>Cube.AddAndExpandDimensionColumn(**cube** as table, **dimensionSelector** as any, **attributeNames** as list, optional **newColumnNames** as any) as table
+<pre>
+Cube.AddAndExpandDimensionColumn(<b>cube</b> as table, <b>dimensionSelector</b> as any, <b>attributeNames</b> as list, optional <b>newColumnNames</b> as any) as table
 </pre>
 
 ## About

--- a/query-languages/m/cube-addmeasurecolumn.md
+++ b/query-languages/m/cube-addmeasurecolumn.md
@@ -7,7 +7,7 @@ title: "Cube.AddMeasureColumn"
 ## Syntax
 
 <pre>
-Cube.AddMeasureColumn(**cube** as table, **column** as text, **measureSelector** as any) as table
+Cube.AddMeasureColumn(<b>cube</b> as table, <b>column</b> as text, <b>measureSelector</b> as any) as table
 </pre>
 
 ## About

--- a/query-languages/m/cube-collapseandremovecolumns.md
+++ b/query-languages/m/cube-collapseandremovecolumns.md
@@ -7,7 +7,7 @@ title: "Cube.CollapseAndRemoveColumns"
 ## Syntax
 
 <pre>
-Cube.CollapseAndRemoveColumns(**cube** as table, **columnNames** as list) as table
+Cube.CollapseAndRemoveColumns(<b>cube</b> as table, <b>columnNames</b> as list) as table
 </pre>
 
 ## About

--- a/query-languages/m/cube-dimensions.md
+++ b/query-languages/m/cube-dimensions.md
@@ -7,7 +7,7 @@ title: "Cube.Dimensions"
 ## Syntax
 
 <pre>
-Cube.Dimensions(**cube** as table) as table
+Cube.Dimensions(<b>cube</b> as table) as table
 </pre>
 
 ## About

--- a/query-languages/m/cube-displayfolders.md
+++ b/query-languages/m/cube-displayfolders.md
@@ -7,7 +7,7 @@ title: "Cube.DisplayFolders"
 ## Syntax
 
 <pre>
-Cube.DisplayFolders(**cube** as table) as table
+Cube.DisplayFolders(<b>cube</b> as table) as table
 </pre>
 
 ## About

--- a/query-languages/m/cube-measures.md
+++ b/query-languages/m/cube-measures.md
@@ -7,7 +7,7 @@ title: "Cube.Measures"
 ## Syntax
 
 <pre>
-Cube.Measures(**cube** as any) as table
+Cube.Measures(<b>cube</b> as any) as table
 </pre>
 
 ## About

--- a/query-languages/m/date-dayofweekname.md
+++ b/query-languages/m/date-dayofweekname.md
@@ -7,7 +7,7 @@ title: "Date.DayOfWeekName"
 ## Syntax
 
 <pre>
-Date.DayOfWeekName(<b>date</b> as any, optional <b>culture</b> as nullable text)
+Date.DayOfWeekName(<b>date</b> as any, optional <b>culture</b> as nullable text) as any
 </pre>
 
 ## About

--- a/query-languages/m/date-dayofweekname.md
+++ b/query-languages/m/date-dayofweekname.md
@@ -7,7 +7,8 @@ title: "Date.DayOfWeekName"
 ## Syntax
 
 <pre>
-Date.DayOfWeekName(<b>date</b> as any, optional <b>culture</b> as nullable text) as any
+Date.DayOfWeekName(<b>date</b> as any, optional <b>culture</b> as nullable text) as nullable text
+
 </pre>
 
 ## About

--- a/query-languages/m/saphana-database.md
+++ b/query-languages/m/saphana-database.md
@@ -7,7 +7,7 @@ title: "SapHana.Database"
 ## Syntax
 
 <pre>
-SapHana.Database(**server** as text, optional **options** as nullable record) as table
+SapHana.Database(<b>server</b> as text, optional <b>options</b> as nullable record) as table
 </pre>
 
 ## About


### PR DESCRIPTION
Some function signatures had their argument names placed between two stars on either side. This commit changes them to <b>...</b> to align them with those found in the majority of *.md files.