### PR TITLE
Type.Is Nullable Type Rule Clarification

### DIFF
--- a/query-languages/m/type-is.md
+++ b/query-languages/m/type-is.md
@@ -12,7 +12,9 @@ Type.Is(<b>type1</b> as type, <b>type2</b> as type) as logical
 
 ## About
 
-Determines if a value of `type1` is always compatible with `type2`.
+Determines if a value of `type1` is always compatible with `type2`. 
+
+Parameter `type2` is expected to be a nullable primitive type. When this requirement is not met, this function's behavior is undefined and so should not be relied on.
 
 ## Example 1
 

--- a/query-languages/m/type-is.md
+++ b/query-languages/m/type-is.md
@@ -14,7 +14,7 @@ Type.Is(<b>type1</b> as type, <b>type2</b> as type) as logical
 
 Determines if a value of `type1` is always compatible with `type2`. 
 
-Parameter `type2` should be a primitive type value or a nullable primitive type value. When this requirement is not met, this function's behavior is undefined and so should not be relied on.
+Parameter `type2` should be a primitive (or nullable primitive) type value. Otherwise, this function's behavior is undefined and shouldn't be relied on.
 
 ## Example 1
 

--- a/query-languages/m/type-is.md
+++ b/query-languages/m/type-is.md
@@ -14,7 +14,7 @@ Type.Is(<b>type1</b> as type, <b>type2</b> as type) as logical
 
 Determines if a value of `type1` is always compatible with `type2`. 
 
-Parameter `type2` is expected to be a nullable primitive type. When this requirement is not met, this function's behavior is undefined and so should not be relied on.
+Parameter `type2` should be a primitive type value or a nullable primitive type value. When this requirement is not met, this function's behavior is undefined and so should not be relied on.
 
 ## Example 1
 


### PR DESCRIPTION
Per https://learn.microsoft.com/en-us/powerquery-m/m-spec-types#type-equivalence-and-compatibility, this function's second parameter should only ever be a nullable primitive type. 

This PR adds details about this requirement to the function's docs.