### PR TITLE
Fixed incorrect result type of duration-duration division

### DIFF
--- a/query-languages/m/m-spec-operators.md
+++ b/query-languages/m/m-spec-operators.md
@@ -1008,7 +1008,7 @@ The interpretation of the division operator (`x / y`) is dependent on the kind o
 | `type number` | `null` | `null` | |
 | `null` | `type number` | `null` | |
 | `type duration` | `type number` | `type duration` | Fraction of duration |
-| `type duration` | `type duration` | `type duration` | Numeric quotient of durations |
+| `type duration` | `type duration` | `type number` | Numeric quotient of durations |
 | `type duration` | `null` | `null` | |
 | `null` | `type duration` | `null` | |
 


### PR DESCRIPTION
Hello.

I think the *Division operator* table has an incorrect value for the duration-duration division.

Table states `duration / duration` will produce a `duration`. However it seems to be contradicted by the subsequent *Quotient of durations* section:

> The quotient of two durations is the <mark>**number**</mark> representing the quotient of the number of 100nanosecond ticks represented by the durations. For example:
> ```
> #duration(2,0,0,0) / #duration(0,1,30,0) 
> // 32
> ```

It is also contradicted by this simple test expression I created, which produces `FALSE`:

```
(#duration(1,0,0,0) / #duration(0,5,0,0)) is duration
```

Am I correct? Or is there something I don't understand?