### PR TITLE
Time Intelligence corrections to reflect actual implementation

### DIFF
--- a/query-languages/dax/nextday-function-dax.md
+++ b/query-languages/dax/nextday-function-dax.md
@@ -6,7 +6,7 @@ title: "NEXTDAY function (DAX) | Microsoft Docs"
 
 [!INCLUDE[applies-to-measures-columns-tables-visual-calculations-discouraged](includes/applies-to-measures-columns-tables-visual-calculations-discouraged.md)]
 
-Returns a table that contains a column of all dates from the next day, based on the last date specified in the **dates** column in the current context.  
+Returns a table that contains a column of all dates in the next day, based on the last date specified in the **dates** column in the current context.  
   
 ## Syntax  
   
@@ -26,7 +26,7 @@ A table containing a single column of date values.
   
 ## Remarks
 
-- This function returns all dates from the next day to the last date in the input parameter. For example, if the last date in the **dates** argument refers to June 10, 2009; then this function returns all dates equal to June 11, 2009.  
+- This function returns all dates in the next day, based on last date in the input parameter. For example, if the last date in the **dates** argument refers to June 10, 2009; then this function returns all dates equal to June 11, 2009.  
   
 - The **dates** argument can be any of the following:  
   - A reference to a date/time column.  

--- a/query-languages/dax/nextday-function-dax.md
+++ b/query-languages/dax/nextday-function-dax.md
@@ -6,7 +6,7 @@ title: "NEXTDAY function (DAX) | Microsoft Docs"
 
 [!INCLUDE[applies-to-measures-columns-tables-visual-calculations-discouraged](includes/applies-to-measures-columns-tables-visual-calculations-discouraged.md)]
 
-Returns a table that contains a column of all dates from the next day, based on the first date specified in the **dates** column in the current context.  
+Returns a table that contains a column of all dates from the next day, based on the last date specified in the **dates** column in the current context.  
   
 ## Syntax  
   
@@ -26,7 +26,7 @@ A table containing a single column of date values.
   
 ## Remarks
 
-- This function returns all dates from the next day to the first date in the input parameter. For example, if the first date in the **dates** argument refers to June 10, 2009; then this function returns all dates equal to June 11, 2009.  
+- This function returns all dates from the next day to the last date in the input parameter. For example, if the last date in the **dates** argument refers to June 10, 2009; then this function returns all dates equal to June 11, 2009.  
   
 - The **dates** argument can be any of the following:  
   - A reference to a date/time column.  

--- a/query-languages/dax/nextmonth-function-dax.md
+++ b/query-languages/dax/nextmonth-function-dax.md
@@ -6,7 +6,7 @@ title: "NEXTMONTH function (DAX) | Microsoft Docs"
 
 [!INCLUDE[applies-to-measures-columns-tables-visual-calculations-discouraged](includes/applies-to-measures-columns-tables-visual-calculations-discouraged.md)]
 
-Returns a table that contains a column of all dates from the next month, based on the last date in the **dates** column in the current context.  
+Returns a table that contains a column of all dates in the next month, based on the last date in the **dates** column in the current context.  
   
 ## Syntax  
   
@@ -26,7 +26,7 @@ A table containing a single column of date values.
   
 ## Remarks
 
-- This function returns all dates from the next month to the last date in the input parameter. For example, if the last date in the **dates** argument refers to June 10, 2009; then this function returns all dates for the month of July, 2009.  
+- This function returns all dates in the next month, based on the last date in the input parameter. For example, if the last date in the **dates** argument refers to June 10, 2009; then this function returns all dates for the month of July, 2009.  
   
 - The **dates** argument can be any of the following:  
   - A reference to a date/time column.  

--- a/query-languages/dax/nextmonth-function-dax.md
+++ b/query-languages/dax/nextmonth-function-dax.md
@@ -6,7 +6,7 @@ title: "NEXTMONTH function (DAX) | Microsoft Docs"
 
 [!INCLUDE[applies-to-measures-columns-tables-visual-calculations-discouraged](includes/applies-to-measures-columns-tables-visual-calculations-discouraged.md)]
 
-Returns a table that contains a column of all dates from the next month, based on the first date in the **dates** column in the current context.  
+Returns a table that contains a column of all dates from the next month, based on the last date in the **dates** column in the current context.  
   
 ## Syntax  
   
@@ -26,7 +26,7 @@ A table containing a single column of date values.
   
 ## Remarks
 
-- This function returns all dates from the next day to the first date in the input parameter. For example, if the first date in the **dates** argument refers to June 10, 2009; then this function returns all dates for the month of July, 2009.  
+- This function returns all dates from the next month to the last date in the input parameter. For example, if the last date in the **dates** argument refers to June 10, 2009; then this function returns all dates for the month of July, 2009.  
   
 - The **dates** argument can be any of the following:  
   - A reference to a date/time column.  

--- a/query-languages/dax/nextquarter-function-dax.md
+++ b/query-languages/dax/nextquarter-function-dax.md
@@ -6,7 +6,7 @@ title: "NEXTQUARTER function (DAX) | Microsoft Docs"
 
 [!INCLUDE[applies-to-measures-columns-tables-visual-calculations-discouraged](includes/applies-to-measures-columns-tables-visual-calculations-discouraged.md)]
 
-Returns a table that contains a column of all dates in the next quarter, based on the first date specified in the **dates** column, in the current context.  
+Returns a table that contains a column of all dates in the next quarter, based on the last date specified in the **dates** column, in the current context.  
   
 ## Syntax  
   
@@ -26,7 +26,7 @@ A table containing a single column of date values.
   
 ## Remarks
 
-- This function returns all dates in the next quarter, based on the first date in the input parameter. For example, if the first date in the **dates** column refers to June 10, 2009, this function returns all dates for the quarter July to September, 2009.  
+- This function returns all dates in the next quarter, based on the last date in the input parameter. For example, if the last date in the **dates** column refers to June 10, 2009, this function returns all dates for the quarter July to September, 2009.  
   
 - The **dates** argument can be any of the following:  
   - A reference to a date/time column.  

--- a/query-languages/dax/nextyear-function-dax.md
+++ b/query-languages/dax/nextyear-function-dax.md
@@ -6,7 +6,7 @@ title: "NEXTYEAR function (DAX) | Microsoft Docs"
 
 [!INCLUDE[applies-to-measures-columns-tables-visual-calculations-discouraged](includes/applies-to-measures-columns-tables-visual-calculations-discouraged.md)]
 
-Returns a table that contains a column of all dates in the next year, based on the first date in the **dates** column, in the current context.  
+Returns a table that contains a column of all dates in the next year, based on the last date in the **dates** column, in the current context.  
   
 ## Syntax  
   
@@ -27,7 +27,7 @@ A table containing a single column of date values.
   
 ## Remarks
 
-- This function returns all dates in the next year, based on the first date in the input column. For example, if the first date in the **dates** column refers to the year 2007, this function returns all dates for the year 2008.  
+- This function returns all dates in the next year, based on the last date in the input column. For example, if the last date in the **dates** column refers to the year 2007, this function returns all dates for the year 2008.  
   
 - The **dates** argument can be any of the following:  
   - A reference to a date/time column.

--- a/query-languages/dax/previousyear-function-dax.md
+++ b/query-languages/dax/previousyear-function-dax.md
@@ -6,7 +6,7 @@ title: "PREVIOUSYEAR function (DAX) | Microsoft Docs"
 
 [!INCLUDE[applies-to-measures-columns-tables-visual-calculations-discouraged](includes/applies-to-measures-columns-tables-visual-calculations-discouraged.md)]
 
-Returns a table that contains a column of all dates from the previous year, given the last date in the **dates** column, in the current context.  
+Returns a table that contains a column of all dates from the previous year, given the first date in the **dates** column, in the current context.  
   
 ## Syntax  
   
@@ -27,7 +27,7 @@ A table containing a single column of date values.
   
 ## Remarks
 
-- This function returns all dates from the previous year given the latest date in the input parameter. For example, if the latest date in the **dates** argument refers to the year 2009, then this function returns all dates for the year of 2008, up to the specified **year_end_date**.  
+- This function returns all dates from the previous year, using the first date in the column used as input. For example, if the first date in the **dates** argument refers to the year 2009, then this function returns all dates for the year of 2008, up to the specified **year_end_date**.  
   
 - The **dates** argument can be any of the following:  
   - A reference to a date/time column.

--- a/query-languages/dax/time-intelligence-functions-dax.md
+++ b/query-languages/dax/time-intelligence-functions-dax.md
@@ -26,8 +26,8 @@ Data Analysis Expressions (DAX) includes time-intelligence functions that enable
 |[FIRSTNONBLANK](firstnonblank-function-dax.md)     | Returns the first value in the column, column, filtered by the current context, where the expression is not blank        |
 |[LASTDATE](lastdate-function-dax.md)      |  Returns the last date in the current context for the specified column of dates.       |
 |[LASTNONBLANK](lastnonblank-function-dax.md)      |  Returns the last value in the column, column, filtered by the current context, where the expression is not blank.       |
-|[NEXTDAY](nextday-function-dax.md)      |  Returns a table that contains a column of all dates from the next day, based on the last date specified in the dates column in the current context.       |
-|[NEXTMONTH](nextmonth-function-dax.md)     |  Returns a table that contains a column of all dates from the next month, based on the last date in the dates column in the current context.       |
+|[NEXTDAY](nextday-function-dax.md)      |  Returns a table that contains a column of all dates in the next day, based on the last date specified in the dates column in the current context.       |
+|[NEXTMONTH](nextmonth-function-dax.md)     |  Returns a table that contains a column of all dates in the next month, based on the last date in the dates column in the current context.       |
 |[NEXTQUARTER](nextquarter-function-dax.md)     |  Returns a table that contains a column of all dates in the next quarter, based on the last date specified in the dates column, in the current context.        |
 |[NEXTYEAR](nextyear-function-dax.md)      | Returns a table that contains a column of all dates in the next year, based on the last date in the dates column, in the current context.          |
 |[OPENINGBALANCEMONTH](openingbalancemonth-function-dax.md)     | Evaluates the expression at the first date of the month in the current context.         |

--- a/query-languages/dax/time-intelligence-functions-dax.md
+++ b/query-languages/dax/time-intelligence-functions-dax.md
@@ -26,10 +26,10 @@ Data Analysis Expressions (DAX) includes time-intelligence functions that enable
 |[FIRSTNONBLANK](firstnonblank-function-dax.md)     | Returns the first value in the column, column, filtered by the current context, where the expression is not blank        |
 |[LASTDATE](lastdate-function-dax.md)      |  Returns the last date in the current context for the specified column of dates.       |
 |[LASTNONBLANK](lastnonblank-function-dax.md)      |  Returns the last value in the column, column, filtered by the current context, where the expression is not blank.       |
-|[NEXTDAY](nextday-function-dax.md)      |  Returns a table that contains a column of all dates from the next day, based on the first date specified in the dates column in the current context.       |
-|[NEXTMONTH](nextmonth-function-dax.md)     |  Returns a table that contains a column of all dates from the next month, based on the first date in the dates column in the current context.       |
-|[NEXTQUARTER](nextquarter-function-dax.md)     |  Returns a table that contains a column of all dates in the next quarter, based on the first date specified in the dates column, in the current context.        |
-|[NEXTYEAR](nextyear-function-dax.md)      | Returns a table that contains a column of all dates in the next year, based on the first date in the dates column, in the current context.          |
+|[NEXTDAY](nextday-function-dax.md)      |  Returns a table that contains a column of all dates from the next day, based on the last date specified in the dates column in the current context.       |
+|[NEXTMONTH](nextmonth-function-dax.md)     |  Returns a table that contains a column of all dates from the next month, based on the last date in the dates column in the current context.       |
+|[NEXTQUARTER](nextquarter-function-dax.md)     |  Returns a table that contains a column of all dates in the next quarter, based on the last date specified in the dates column, in the current context.        |
+|[NEXTYEAR](nextyear-function-dax.md)      | Returns a table that contains a column of all dates in the next year, based on the last date in the dates column, in the current context.          |
 |[OPENINGBALANCEMONTH](openingbalancemonth-function-dax.md)     | Evaluates the expression at the first date of the month in the current context.         |
 |[OPENINGBALANCEQUARTER](openingbalancequarter-function-dax.md)     | Evaluates the expression at the first date of the quarter, in the current context.         |
 |[OPENINGBALANCEYEAR](openingbalanceyear-function-dax.md)       |  Evaluates the expression at the first date of the year in the current context.       |

--- a/query-languages/dax/time-intelligence-functions-dax.md
+++ b/query-languages/dax/time-intelligence-functions-dax.md
@@ -37,7 +37,7 @@ Data Analysis Expressions (DAX) includes time-intelligence functions that enable
 |[PREVIOUSDAY](previousday-function-dax.md)      | Returns a table that contains a column of all dates representing the day that is previous to the first date in the dates column, in the current context.        |
 |[PREVIOUSMONTH](previousmonth-function-dax.md)     |  Returns a table that contains a column of all dates from the previous month, based on the first date in the dates column, in the current context.       |
 |[PREVIOUSQUARTER](previousquarter-function-dax.md)      |  Returns a table that contains a column of all dates from the previous quarter, based on the first date in the dates column, in the current context.       |
-|[PREVIOUSYEAR](previousyear-function-dax.md)       |  Returns a table that contains a column of all dates from the previous year, given the last date in the dates column, in the current context.        |
+|[PREVIOUSYEAR](previousyear-function-dax.md)       |  Returns a table that contains a column of all dates from the previous year, given the first date in the dates column, in the current context.        |
 |[SAMEPERIODLASTYEAR](sameperiodlastyear-function-dax.md)     |  Returns a table that contains a column of dates shifted one year back in time from the dates in the specified dates column, in the current context.       |
 |[STARTOFMONTH](startofmonth-function-dax.md)     | Returns the first date of the month in the current context for the specified column of dates.          |
 |[STARTOFQUARTER](startofquarter-function-dax.md)     |  Returns the first date of the quarter in the current context for the specified column of dates.         |


### PR DESCRIPTION
NEXTDAY, NEXTMONTH, NEXTQUARTER, NEXTYEAR are all using the last date (not the first as stated in the docs).
PREVIOUSYEAR is using the first date (not the last date as stated in the docs).