### PR TITLE
Update userelationship-function-dax.md

### DIFF
--- a/query-languages/dax/userelationship-function-dax.md
+++ b/query-languages/dax/userelationship-function-dax.md
@@ -55,4 +55,4 @@ To calculate the sum of internet sales and allow slicing by ShippingDate instead
 = CALCULATE(SUM(InternetSales[SalesAmount]), USERELATIONSHIP(InternetSales[ShippingDate], DateTime[Date]))
 ```
 
-Relationships between InternetSales[ShipmentDate] and DateTime[Date] must exist and should not be the active relationship; also, the relationship between InternetSales[OrderDate] and DateTime[Date] should exist and should be the active relationship.
+Relationships between InternetSales[ShippingDate] and DateTime[Date] must exist and should not be the active relationship; also, the relationship between InternetSales[OrderDate] and DateTime[Date] should exist and should be the active relationship.


### PR DESCRIPTION
Reference on the bottom DAX was to [ShipmentDate] and not the [ShippingDate] used in the code example above, changed to line up to remove ambiguity.