### PR TITLE
Updating Table.AddJoinColumn

### DIFF
--- a/query-languages/m/table-addjoincolumn.md
+++ b/query-languages/m/table-addjoincolumn.md
@@ -21,7 +21,7 @@ Table.AddJoinColumn(
 
 ## About
 
-Joins the rows of `table1` with the rows of `table2` based on the equality of the values of the key columns selected by `key1` (for `table1`) and `key2` (for `table2`). The results are entered into the column named `newColumnName`. 
+Joins the rows of `table1` with the rows of `table2` based on the equality of the values of the key columns selected by `key1` (for `table1`) and `key2` (for `table2`). The results are stored in a column named `newColumnName`.
 
 This function behaves identically to [`Table.NestedJoin`](table-nestedjoin.md) with a JoinKind of LeftOuter.
 

--- a/query-languages/m/table-addjoincolumn.md
+++ b/query-languages/m/table-addjoincolumn.md
@@ -21,7 +21,9 @@ Table.AddJoinColumn(
 
 ## About
 
-Joins the rows of `table1` with the rows of `table2` based on the equality of the values of the key columns selected by `key1` (for `table1`) and `key2` (for `table2`). The results are entered into the column named `newColumnName`. This function behaves similarly to [`Table.Join`](table-join.md) with a JoinKind of LeftOuter except that the join results are presented in a nested rather than flattened fashion.
+Joins the rows of `table1` with the rows of `table2` based on the equality of the values of the key columns selected by `key1` (for `table1`) and `key2` (for `table2`). The results are entered into the column named `newColumnName`. 
+
+This function behaves identically to [`Table.NestedJoin`](table-nestedjoin.md) with a JoinKind of LeftOuter.
 
 ## Example
 
@@ -36,7 +38,7 @@ Table.AddJoinColumn(
         [saleID = 2, item = "Hat"]
     }),
     "saleID",
-    () => Table.FromRecords({
+    Table.FromRecords({
         [saleID = 1, price = 20, stock = 1234],
         [saleID = 2, price = 10, stock = 5643]
     }),

--- a/query-languages/m/table-addjoincolumn.md
+++ b/query-languages/m/table-addjoincolumn.md
@@ -23,7 +23,7 @@ Table.AddJoinColumn(
 
 Joins the rows of `table1` with the rows of `table2` based on the equality of the values of the key columns selected by `key1` (for `table1`) and `key2` (for `table2`). The results are stored in a column named `newColumnName`.
 
-This function behaves identically to [`Table.NestedJoin`](table-nestedjoin.md) with a JoinKind of LeftOuter.
+This function behaves identically to [`Table.NestedJoin`](table-nestedjoin.md) with `joinKind` set to [`JoinKind.LeftOuter`](joinkind-type.md).
 
 ## Example
 


### PR DESCRIPTION
Revising description to indicate the identicalness of behavior with `Table.NestedJoin`; updating example to use more common syntax.