### PR TITLE
Trying to fix incorrectly described behavior regarding NATURALINNERJOIN()

### DIFF
--- a/query-languages/dax/naturalinnerjoin-function-dax.md
+++ b/query-languages/dax/naturalinnerjoin-function-dax.md
@@ -28,7 +28,7 @@ A table which includes only rows for which the values in the common columns spec
 
 ## Remarks
 
-- Tables are joined on common columns (by name) in the two tables. If the two tables have no common column names, an error is returned.
+- Tables are joined based on an existing relationship existing between them in the model. For the join to work, the names of the columns used for the joining need to be distinct, otherwise an error is returned.
 
 - There is no sort order guarantee for the results.
 


### PR DESCRIPTION
I couldn't be more uncertain of what I'm suggesting to merge... I hate doing this but I'm resorting to [Cunningham's Law](https://meta.wikimedia.org/wiki/Cunningham%27s_Law) so that the truth will manifest itself! 😅 I would have posted an issue in this repository if the section existed but apparently this isn't the case.

Documentation about `NATURALINNERJOIN()` seems to be currently incorrect according to some of my tests and various posts online. If I'm correct about this, it might be worth checking descriptions of similar functions such as `NATURALLEFTOUTERJOIN()` (and others if any?).

`NATURALINNERJOIN()` seems to have specific use cases so I think that describing those and adding short recommendations about potentially"cleaner" alternatives such as `RELATED()`, `RELATEDTABLE()` and `LOOKUPVALUE()` might be worth considering (according to Copilot).